### PR TITLE
key-add is deprecated

### DIFF
--- a/templates/weave_flux_pipeline.cfn.yml
+++ b/templates/weave_flux_pipeline.cfn.yml
@@ -161,7 +161,9 @@ Resources:
               runtime-versions:
                 docker: 18
               commands:
-                - curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+                - sudo mkdir /usr/share/keyrings
+                - KEYRING=/usr/share/keyrings/yarnpkg.gpg
+                - curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo tee "$KEYRING" >/dev/null
                 - apt-get -y update
                 - apt-get -y install jq
             pre_build:


### PR DESCRIPTION
Using different way to store gpg as key-add has been deprecated and causing issues during build.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
